### PR TITLE
verify product status before add document

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,6 @@
   },
   "engines": {
     "node": ">=20"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/subscribers/meilisearch-product-upsert.ts
+++ b/src/subscribers/meilisearch-product-upsert.ts
@@ -12,7 +12,14 @@ export default async function meilisearchProductUpsertHandler({
   const meilisearchService: MeiliSearchService = container.resolve('meilisearch')
 
   const product = await productModuleService.retrieveProduct(productId)
-  await meilisearchService.addDocuments('products', [product], SearchUtils.indexTypes.PRODUCTS)
+
+  if (product.status === 'published') {
+    // If status is "published", add or update the document in MeiliSearch
+    await meilisearchService.addDocuments('products', [product], SearchUtils.indexTypes.PRODUCTS)
+  } else {
+    // If status is not "published", remove the document from MeiliSearch
+    await meilisearchService.deleteDocument('products', productId)
+  }
 }
 
 export const config: SubscriberConfig = {


### PR DESCRIPTION
Currently when a product is updated no matter what is the status (eg: draft, reject) still can be indexed.